### PR TITLE
A few more tweaks to CardSetApiClient

### DIFF
--- a/ArtifactDeckCodeDotNet.Tests/CardSetApiClientTests.cs
+++ b/ArtifactDeckCodeDotNet.Tests/CardSetApiClientTests.cs
@@ -10,7 +10,7 @@ namespace ArtifactDeckCodeDotNet.Tests
         {
             using (CardSetApiClient client = new CardSetApiClient())
             {
-                CardSet result = await client.GetCardSetAsync("00");
+                CardSet result = await client.GetCardSetAsync(0);
 
                 Assert.Equal(1, result.Version);
                 Assert.Equal(0, result.SetInfo.SetId);
@@ -24,7 +24,7 @@ namespace ArtifactDeckCodeDotNet.Tests
         {
             using (CardSetApiClient client = new CardSetApiClient())
             {
-                CardSet result = await client.GetCardSetAsync("01");
+                CardSet result = await client.GetCardSetAsync(1);
 
                 Assert.Equal(1, result.Version);
                 Assert.Equal(1, result.SetInfo.SetId);
@@ -38,7 +38,7 @@ namespace ArtifactDeckCodeDotNet.Tests
         {
             CardSetApiClient client = new CardSetApiClient();
 
-            await Assert.ThrowsAsync<CardSetApiClientException>(() => client.GetCardSetAsync("02"));
+            await Assert.ThrowsAsync<CardSetApiClientException>(() => client.GetCardSetAsync(2));
         }
     }
 }

--- a/ArtifactDeckCodeDotNet/CardSetApiClient.cs
+++ b/ArtifactDeckCodeDotNet/CardSetApiClient.cs
@@ -10,7 +10,7 @@ namespace ArtifactDeckCodeDotNet
     public class CardSetApiClient : IDisposable
     {
         HttpClient _httpClient;
-        Lazy<CardSetDataCache> _cache;
+        Lazy<Cache<uint, CardSetData>> _cache;
 
         private static string DataCacheFile = Path.Combine(Path.GetTempPath(), "ArtifactSetDataCache.json");
 
@@ -21,12 +21,12 @@ namespace ArtifactDeckCodeDotNet
         public CardSetApiClient(HttpClient httpClient)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            _cache = new Lazy<CardSetDataCache>(() => new CardSetDataCache(DataCacheFile));
+            _cache = new Lazy<Cache<uint, CardSetData>>(() => new Cache<uint, CardSetData>(DataCacheFile));
         }
 
-        public async Task<CardSet> GetCardSetAsync(string setId, bool forceFetch = false)
+        public async Task<CardSet> GetCardSetAsync(uint setId, bool forceFetch = false)
         {
-            CardSetDataCache dataCache = _cache.Value;
+            Cache<uint, CardSetData> dataCache = _cache.Value;
             if (forceFetch ||
                 !dataCache.TryGetValue(setId, out var data) ||
                 data.ExpireTimeUtc < DateTimeOffset.UtcNow)
@@ -46,9 +46,9 @@ namespace ArtifactDeckCodeDotNet
             }
         }
 
-        private static Uri CardSetInfoUrl(string setId) => new Uri($"https://playartifact.com/cardset/{setId}");
+        private static Uri CardSetInfoUrl(uint setId) => new Uri($"https://playartifact.com/cardset/{setId:D2}");
 
-        private async Task<CardSetData> FetchCardSetData(string setId)
+        private async Task<CardSetData> FetchCardSetData(uint setId)
         {
             CardSetJsonLocation jsonLocation = await FetchCardSetLocation(CardSetInfoUrl(setId));
             CardSetData cardSetData = await FetchCardSetData(jsonLocation.GetFullUri());
@@ -85,32 +85,27 @@ namespace ArtifactDeckCodeDotNet
             }
         }
 
-        private class CardSetDataCache : IDisposable
+        private class Cache<TKey, TValue> : IDisposable
         {
             private readonly string _cacheFilePath;
-            private readonly Dictionary<string, CardSetData> _data;
+            private readonly Dictionary<TKey, TValue> _data;
 
-            public ICollection<string> Keys { get; }
-            public ICollection<CardSetData> Values { get; }
-            public int Count { get; }
-            public bool IsReadOnly { get; }
-
-            public CardSetDataCache(string filePath)
+            public Cache(string filePath)
             {
                 _cacheFilePath = filePath;
                 _data = ReadDataFromDisk(filePath);
             }
 
-            public CardSetData this[string setId]
+            public TValue this[TKey key]
             {
-                get => _data[setId];
-                set => _data[setId] = value;
+                get => _data[key];
+                set => _data[key] = value;
             }
 
-            public bool TryGetValue(string key, out CardSetData value)
+            public bool TryGetValue(TKey key, out TValue value)
                 => _data.TryGetValue(key, out value);
 
-            public bool Remove(string key) => _data.Remove(key);
+            public bool Remove(TKey key) => _data.Remove(key);
 
             public void Clear() => _data.Clear();
 
@@ -128,17 +123,17 @@ namespace ArtifactDeckCodeDotNet
                 catch (IOException) { }
             }
 
-            private static Dictionary<string, CardSetData> ReadDataFromDisk(string filePath)
+            private static Dictionary<TKey, TValue> ReadDataFromDisk(string filePath)
             {
                 try
                 {
                     JsonSerializer serializer = new JsonSerializer();
                     var fileContents = File.ReadAllText(filePath);
-                    return JsonConvert.DeserializeObject<Dictionary<string, CardSetData>>(fileContents);
+                    return JsonConvert.DeserializeObject<Dictionary<TKey, TValue>>(fileContents);
                 }
                 catch
                 {
-                    return new Dictionary<string, CardSetData>();
+                    return new Dictionary<TKey, TValue>();
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The CardSetApiClient allows you to request details on all cards in Artifact by s
 ```csharp
 using(var apiClient = new CardSetApiClient())
 {
-    CardSet cardSet = await client.GetCardSetAsync("00");
+    CardSet cardSet = await client.GetCardSetAsync(0);
 
     Console.WriteLine(cardSet.Version); //outputs "1"
     Console.WriteLine(cardSet.SetInfo.Name.English); //outputs "Base Set"


### PR DESCRIPTION
Change API to specify set id as an unsigned integer.
Rename CardSetDataCache to Cache and make the class generic, so as not to hard code the key/value types.
Remove a few unimplemented methods added accidentally by VS.